### PR TITLE
Fix latex support

### DIFF
--- a/Maxwell_Reciprocity/description.html
+++ b/Maxwell_Reciprocity/description.html
@@ -38,18 +38,18 @@ code {
 <h1>Maxwell's Reciprocity Betti's Theorem</h1>
 
 <p>
- Maxwell's reciprocity states that a point \(i\) subjected to a force which causes a deflection at point \(j\), will experience the same amount of deflection if the same force is applied to point \(j\)
+ Maxwell's reciprocity states that a point $i$ subjected to a force which causes a deflection at point $j$, will experience the same amount of deflection if the same force is applied to point $j$
 </p>
 
 
 Important properties to note:
 <p>
 <ul>
-  <li> A frame with height \(a\) and length \(b\) is subjected to a load which causes the frame to deform. </li>
+  <li> A frame with height $a$ and length $b$ is subjected to a load which causes the frame to deform. </li>
   <li> One leg of the frame is stationary while the other leg is able to move freely. </li>
   <li> The magnitude of the force is controlled by the 'Magnitude' slider. </li>
   <li> The position of the force is controlled by the 'Position' slider. </li>
-  <li> Once satisfied with the location and magnitude of \(F_1\), the location is saved by clicking 'Save Deformed Frame'.
-  This will also activate the second frame and force \(F_2\). </li>
+  <li> Once satisfied with the location and magnitude of $F_1$, the location is saved by clicking 'Save Deformed Frame'.
+  This will also activate the second frame and force $F_2$. </li>
   <li> In order to return back to a clean slate, click the 'Reset' button. </li>
 </ul>

--- a/Maxwell_Reciprocity/description1.html
+++ b/Maxwell_Reciprocity/description1.html
@@ -37,32 +37,32 @@ code {
 
  <h4> Theory </h4>
  <p>
-   In order to prove the reciprocal nature of two loads, consider a simple linear beam with a force \(F_{1}\) at point \(i\) and another force \(F_{2}\) at point \(j\) .
+   In order to prove the reciprocal nature of two loads, consider a simple linear beam with a force $F_{1}$ at point $i$ and another force $F_{2}$ at point $j$ .
 </p>
    <ul>
-   <li> Let \(F_{1}\) at point \(i\) produce a deflection \(w_{ji}\) at point \(j\) and a deflection \(w_{ii}\) at point \(i\).</li>
-   <li> Let \(F_{2}\) at point \(j\) produce a deflection \(w_{ij}\) at point \(i\) and a deflection \(w_{jj}\) at point \(j\).</li>
-   <li> Let the total resultant work done be the same, regardless if \(F_{1}\) is applied first or if \(F_{2}\) is applied first. ( \(W_{1} = W_{2}\) ) </li>
-   <li> Let both forces be equal (\(F_{1} = F_{2}\) ) </li>
+   <li> Let $F_{1}$ at point $i$ produce a deflection $w_{ji}$ at point $j$ and a deflection $w_{ii}$ at point $i$.</li>
+   <li> Let $F_{2}$ at point $j$ produce a deflection $w_{ij}$ at point $i$ and a deflection $w_{jj}$ at point $j$.</li>
+   <li> Let the total resultant work done be the same, regardless if $F_{1}$ is applied first or if $F_{2}$ is applied first. ( $W_{1} = W_{2}$ ) </li>
+   <li> Let both forces be equal ($F_{1} = F_{2}$ ) </li>
    </ul>
 
 <p>
-  Since the total work will be the same independent of whether \(F_{1}\) or \(F_{2}\) is applied to the beam first, the work can described in the following way:
+  Since the total work will be the same independent of whether $F_{1}$ or $F_{2}$ is applied to the beam first, the work can described in the following way:
 </p>
   <ul>
-   <li> Case 1: \(W_{1}\) is the work when \(F_{2}\) is applied first and then \(F_{1}\) is applied. </li>
-   <li> Case 2: \(W_{2}\) is the work when \(F_{1}\) is applied first and then \(F_{2}\) is applied. </li>
-   <li> After both forces have been applied, it is easy to see that \(W_{1} = W_{2}\) in both cases.
+   <li> Case 1: $W_{1}$ is the work when $F_{2}$ is applied first and then $F_{1}$ is applied. </li>
+   <li> Case 2: $W_{2}$ is the work when $F_{1}$ is applied first and then $F_{2}$ is applied. </li>
+   <li> After both forces have been applied, it is easy to see that $W_{1} = W_{2}$ in both cases.
   </ul>
 
 <p>
   By setting the work equal to each other, we end up with the following equations:
-  $$ W_{1} = {1/2} F_{2} w_{jj} + 1/2 F_{1} w_{ii} + F_{2} w_{ji} $$
-  $$ W_{2} = 1/2 F_{1} w_{ii} + 1/2 F_{2} w_{jj} + F_{1} w_{ij} $$
-  $$ 1/2 F_{2} w_{jj} + 1/2 F_{1} w_{ii} + F_{2} w_{ji} = 1/2 F_{1} w_{ii} + 1/2 F_{2} w_{jj} + F_{1} w_{ij} $$
+  \[ W_{1} = {1/2} F_{2} w_{jj} + 1/2 F_{1} w_{ii} + F_{2} w_{ji} \]
+  \[ W_{2} = 1/2 F_{1} w_{ii} + 1/2 F_{2} w_{jj} + F_{1} w_{ij} \]
+  \[ 1/2 F_{2} w_{jj} + 1/2 F_{1} w_{ii} + F_{2} w_{ji} = 1/2 F_{1} w_{ii} + 1/2 F_{2} w_{jj} + F_{1} w_{ij} \]
 
   If both Force magnitudes are equal, the equation can be simplified to the final form:
 
-  $$ w_{ji} = w_{ij} $$
+  \[ w_{ji} = w_{ij} \]
 
 </p>

--- a/Maxwell_Reciprocity/main.py
+++ b/Maxwell_Reciprocity/main.py
@@ -5,7 +5,12 @@ from bokeh.models.widgets import Button
 from bokeh.models.glyphs import Text
 from bokeh.io import curdoc
 import numpy as np
-from os.path import dirname, join, split
+from os.path import dirname, join, split, abspath
+import sys, inspect
+currentdir = dirname(abspath(inspect.getfile(inspect.currentframe())))
+parentdir = join(dirname(currentdir), "shared/")
+sys.path.insert(0,parentdir) 
+from latex_div import LatexDiv
 
 
 #main1
@@ -815,8 +820,8 @@ plot.add_layout(labelsw2)
 description_filename = join(dirname(__file__), "description.html")
 description1_filename = join(dirname(__file__), "description1.html")
 
-description = Div(text=open(description_filename).read(), render_as_text=False, width=1200)
-description1 = Div(text=open(description1_filename).read(), render_as_text=False, width=1200)
+description = LatexDiv(text=open(description_filename).read(), render_as_text=False, width=750)
+description1 = LatexDiv(text=open(description1_filename).read(), render_as_text=False, width=750)
 
 
 ################################################################################

--- a/SDOF/description.html
+++ b/SDOF/description.html
@@ -30,16 +30,13 @@ code {
     color: #336699;
 }
 </style>
-<script type="text/javascript" async
-  src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-MML-AM_CHTML">
-</script>
 <head>
 
 <h1>Damped SDOF system </h1>
 
 <p>
 This app shows the motion of a classical single degree of freedom system, cosisting out of a discrete mass, a spring, and a damper element. A harmonic force can also be applied to the system.
-By starting the oscillation, the system oscillates around the static equilibrium position at \(u = 0 \). The displacement plot is normalized with the spring stiffness. No gravity is acting on the system.
+By starting the oscillation, the system oscillates around the static equilibrium position at $u = 0$. The displacement plot is normalized with the spring stiffness. No gravity is acting on the system.
 
 <p> The interactivity parameters are </p>
 <ul>

--- a/SDOF/main.py
+++ b/SDOF/main.py
@@ -10,7 +10,12 @@ from bokeh.models.tickers import FixedTicker
 from bokeh.models.callbacks import CustomJS
 from bokeh.models.widgets import DataTable, TableColumn
 
-from os.path import dirname, join, split
+from os.path import dirname, join, split, abspath
+import sys, inspect
+currentdir = dirname(abspath(inspect.getfile(inspect.currentframe())))
+parentdir = join(dirname(currentdir), "shared/")
+sys.path.insert(0,parentdir) 
+from latex_div import LatexDiv
 from math import sqrt, exp, pow, sin , cos, ceil, pi, atan2, sinh, cosh
 
 ## initial values
@@ -353,7 +358,7 @@ parameter_table = DataTable(source=parameters, columns=columns, reorderable=Fals
 
 # add app description
 description_filename = join(dirname(__file__), "description.html")
-description = Div(text=open(description_filename).read(), render_as_text=False, width=1200)
+description = LatexDiv(text=open(description_filename).read(), render_as_text=False, width=1200)
 
 ## Send to window
 hspace = 20

--- a/shared/latex_div.py
+++ b/shared/latex_div.py
@@ -1,0 +1,28 @@
+from bokeh.models.widgets import Div
+
+JS_CODE = """
+import {Markup, MarkupView} from "models/widgets/markup"
+import {div} from "core/dom"
+import * as p from "core/properties"
+#dom_1 = require( Dom );
+export class LatexDivView extends MarkupView
+    render: () ->
+        super.render()
+        content = div()
+        # content = @div()
+        content.innerHTML = @model.text
+        console.log(content)
+        # console.log(@model.text)
+        #katex.render(@model.text, @el, {displayMode: true})
+        @markupEl.appendChild(content)
+
+export class LatexDiv extends Markup
+    type: 'LatexDiv'
+    default_view: LatexDivView
+
+"""
+
+class LatexDiv(Div):
+    __javascript__ = ["https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.6.0/katex.min.js"]
+    __css__ = ["https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.6.0/katex.min.css"]
+    __implementation__ = "latex_div.ts"

--- a/shared/latex_div.py
+++ b/shared/latex_div.py
@@ -1,27 +1,5 @@
 from bokeh.models.widgets import Div
 
-JS_CODE = """
-import {Markup, MarkupView} from "models/widgets/markup"
-import {div} from "core/dom"
-import * as p from "core/properties"
-#dom_1 = require( Dom );
-export class LatexDivView extends MarkupView
-    render: () ->
-        super.render()
-        content = div()
-        # content = @div()
-        content.innerHTML = @model.text
-        console.log(content)
-        # console.log(@model.text)
-        #katex.render(@model.text, @el, {displayMode: true})
-        @markupEl.appendChild(content)
-
-export class LatexDiv extends Markup
-    type: 'LatexDiv'
-    default_view: LatexDivView
-
-"""
-
 class LatexDiv(Div):
     __javascript__ = ["https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.6.0/katex.min.js"]
     __css__ = ["https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.6.0/katex.min.css"]

--- a/shared/latex_div.ts
+++ b/shared/latex_div.ts
@@ -1,0 +1,102 @@
+import { Markup, MarkupView } from "models/widgets/markup"
+import { div } from "core/dom"
+import * as p from "core/properties"
+
+export class LatexDivView extends MarkupView {
+  model: LatexDiv
+
+  render(): void {
+    super.render()
+    var content = div()
+    if (this.model.render_as_text)
+      content.textContent = this.model.text
+    else {
+      content.innerHTML = this.model.text
+      this.myrender(content)
+    }
+    this.markupEl.appendChild(content)
+  }
+
+  myrender(content): void {
+    // taken from http://sixthform.info/katex/guide.html
+    // replace text dollar signs by %​% temporarily then
+    // replace $...$ by <span class="maths">...</span>
+    // regular expression \$([\s\S]+?)\$/g consists of all whitespace \s 
+    // and non-whitespace characters \S between the dollar signs. See [4]
+    content.innerHTML = content.innerHTML.replace(/\\\$/g, '\%\%');
+    content.innerHTML = content.innerHTML.replace(/\$([\s\S]+?)\$/g, '<span class=\"maths\">$1</span>');
+    // replace \[ ...\] by <div class="maths"> ... </div>
+    // but don't replace eg \\[1ex] so temporarily rename them
+    // content.innerHTML = content.innerHTML.replace(/\\\\\[/g, '%​%​%');
+    content.innerHTML = content.innerHTML.replace(/\\\\\]/g, '%​%​%');
+    content.innerHTML = content.innerHTML.replace(/\\\[/g, '<div class=\"maths\">');
+    content.innerHTML = content.innerHTML.replace(/\\\]/g, '</div>');
+    // put back eg \\[1ex]
+    content.innerHTML = content.innerHTML.replace(/%​%​%/g, '\\\\\]');
+    // replace \( ...\) by <span class="maths"> ... </span>
+    content.innerHTML = content.innerHTML.replace(/\(/g, '<span class=\"maths\">');
+    content.innerHTML = content.innerHTML.replace(/\)/g, '</span>');
+    // put back text dollar signs
+    content.innerHTML = content.innerHTML.replace(/\%\%/g, '\$');
+    console.log(content.innerHTML)
+
+    // Get all <div or span or p class ="maths"> elements in the document
+    var x = content.getElementsByClassName('maths');
+    for (var i = 0; i < x.length; i++) {
+      console.log('jajaja')
+      // t= katex.render(x[i].textContent,x[i],{ displayMode: true }); 
+      // console.log(t)
+      try {
+        if (x[i].tagName == "DIV") {
+          katex.render(x[i].textContent, x[i], { displayMode: true });
+        } else {
+          katex.render(x[i].textContent, x[i]);
+        }
+      }
+      catch (err) {
+        console.log('err')
+        x[i].style.color = 'red';
+        x[i].textContent = err;
+      }
+
+    }
+
+    // Optional. Allows use of delimiters in document without them being replaced
+    // Use \$ or %​% for $, %​[ for \[, %​] for \], %​( for \(, %​) for \)
+    // the following will convert them to the appropriate delimiters
+    // content.innerHTML = content.innerHTML.replace(/\%\\[/g, '\\\[');
+    // content.innerHTML = content.innerHTML.replace(/\%\\]/g, '\\\]');
+    // content.innerHTML = content.innerHTML.replace(/\%\\(/g, '\\\(');
+    // content.innerHTML = content.innerHTML.replace(/\%\\)/g, '\\\)');  
+  }
+}
+
+export namespace LatexDiv {
+  export interface Attrs extends Markup.Attrs {
+    render_as_text: boolean
+  }
+
+  export interface Props extends Markup.Props { }
+}
+
+export interface LatexDiv extends LatexDiv.Attrs { }
+
+export class LatexDiv extends Markup {
+
+  properties: LatexDiv.Props
+
+  constructor(attrs?: Partial<LatexDiv.Attrs>) {
+    super(attrs)
+  }
+
+  static initClass(): void {
+    this.prototype.type = "LatexDiv"
+    this.prototype.default_view = LatexDivView
+
+    this.define({
+      render_as_text: [p.Bool, false],
+    })
+  }
+}
+
+LatexDiv.initClass()


### PR DESCRIPTION
This fixes #24 .
Latex support is made available via the KaTeX library (https://khan.github.io/KaTeX/), because I could not get MathJax to work with Bokeh. A new class `LatexDiv` is implemented, which works the same way as the normal `Div` but parses also Latex input. As it will be used by many apps, I put it into an extra folder, the class can be imported using:

```python
from os.path import dirname, join, split, abspath
import sys, inspect
currentdir = dirname(abspath(inspect.getfile(inspect.currentframe())))
parentdir = join(dirname(currentdir), "shared/")
sys.path.insert(0,parentdir) 
from latex_div import LatexDiv
```
Now, indstead of Div, use LatexDiv, if the document contains Latex code. The identifiers are `$\alpha$` for inline mode and `\[ \alpha \]` for display mode. See Maxwell's reciprocity or the SDOF app, they have already been updated.
